### PR TITLE
Requests for JELP improvement

### DIFF
--- a/modules/JELP/Outgoing.module/Outgoing.pm
+++ b/modules/JELP/Outgoing.module/Outgoing.pm
@@ -322,10 +322,9 @@ sub cum {
 
 # add cmodes
 sub acm {
-    my ($to_server, $serv, $modes) = (shift, shift, '');
+    my ($to_server, $serv, $modes, %prefixes) = (shift, shift, '', ());
     
     # grab and reorder prefixes.
-    %prefixes = ();
     foreach my $level (sort { $b <=> $a } keys %ircd::channel_mode_prefixes) {
         $prefixes{$ircd::channel_mode_prefixes{$level}[2]} =
             [ $ircd::channel_mode_prefixes{$level}[1], $level ];


### PR DESCRIPTION
During development of a JELP abstraction package for my IRCd, I noticed a shortcoming of the protocol that should be easy to fix:

For the `ACM` channel mode burst command, there are three parameters:  `mode_name`, `char`, and `type`.  While this is sufficient for most mode types, when it comes to status modes, it leaves a bit to be desired; I suggest an alteration to the protocol that includes two extra parameters for status modes:  `prefix` and `weight`.  This would provide JELP with the ability to be even more dynamic with modes, rather than relying on predefined mode mappings on either side of a server link.  An example of the desired change is below.

```
SERVER 6 irc.default.tld 6.1 IRCServer-PHP;Modfwango-v1.30 :My owner hasn't given me a proper description yet... :(

SERVER 1 devserver1.example.com 6.1 9.69 :juno development server

PASS k

PASS k
READY

:6 BURST 1417999278
:6 ENDBURST 1417999278

:1 BURST 1417999278
:1 AUM ssl:z registered:r invisible:i ircop:o
:1 ACM free_invite:g:0 forward:f:2 free_forward:F:0 halfop:h:4:%:-1 moderated:m:0 no_ext:n:0 invite_except:I:3 mute:Z:3 ban:b:3 protect_topic:t:0 op:o:4:@:0 secret:s:0 admin:a:4:&:1 except:e:3 invite_only:i:0 key:k:5 voice:v:4:+:-2 access:A:3 limit:l:2 owner:q:4:~:2 oper_only:O:0
:1 ENDBURST 1417999278
```
